### PR TITLE
Fix for libdc1394 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN cd /opt && \
   make install && \
   echo "/usr/local/lib" | sudo tee -a /etc/ld.so.conf.d/opencv.conf && \
   ldconfig
+  ln /dev/null /dev/raw1394
 RUN cp /opt/opencv-3.1.0/build/lib/cv2.so /usr/lib/python2.7/dist-packages/cv2.so
 
 


### PR DESCRIPTION
Fixes this error that occur usually in servers: `libdc1394 error: Failed to initialize libdc1394` . 
Happens while importing caffe or cv2

https://stackoverflow.com/questions/12689304/ctypes-error-libdc1394-error-failed-to-initialize-libdc1394